### PR TITLE
2025.9.1: Update Intel Compute Runtime to v25.35

### DIFF
--- a/ollama-ipex/CHANGELOG.md
+++ b/ollama-ipex/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2025.9.1] 2025-09-30
+
+### Update:
+
+* Intel Graphics Compiler v2.18.0
+* Intel Compute Runtime v25.35
+
 ## [2025.8.1] 2025-08-28
 
 ### Update:

--- a/ollama-ipex/Dockerfile
+++ b/ollama-ipex/Dockerfile
@@ -53,14 +53,14 @@ RUN mkdir -p /tmp/gpu && \
     cd /tmp/gpu && \
     echo "Downloading oneAPI Level Zero Loader v1.24.2..." && \
     wget https://github.com/oneapi-src/level-zero/releases/download/v1.24.2/level-zero_1.24.2+u24.04_amd64.deb && \
-    echo "Downloading Intel Graphics Compiler v2.16.0..." && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.16.0/intel-igc-core-2_2.16.0+19683_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.16.0/intel-igc-opencl-2_2.16.0+19683_amd64.deb && \
-    echo "Downloading Intel Compute Runtime v25.31..." && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/intel-ocloc_25.31.34666.3-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/intel-opencl-icd_25.31.34666.3-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/libigdgmm12_22.8.1_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/libze-intel-gpu1_25.31.34666.3-0_amd64.deb && \
+    echo "Downloading Intel Graphics Compiler v2.18.0..." && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.18.5/intel-igc-core-2_2.18.5+19820_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.18.5/intel-igc-opencl-2_2.18.5+19820_amd64.deb && \
+    echo "Downloading Intel Compute Runtime v25.35..." && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.35.35096.9/intel-ocloc_25.35.35096.9-0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.35.35096.9/intel-opencl-icd_25.35.35096.9-0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.35.35096.9/libigdgmm12_22.8.1_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.35.35096.9/libze-intel-gpu1_25.35.35096.9-0_amd64.deb && \
     dpkg -i --force-all *.deb && \
     rm *.deb
 

--- a/ollama-ipex/config.yaml
+++ b/ollama-ipex/config.yaml
@@ -1,6 +1,6 @@
 name: "Ollama IPEX"
 description: "Get up and running with large language models."
-version: "2025.8.1"
+version: "2025.9.1"
 slug: "ollama-ipex"
 codenotary: notary@home-assistant.io
 arch:


### PR DESCRIPTION
* Intel Graphics Compiler v2.18.0
* Intel Compute Runtime v25.35