### PR TITLE
2026.3.1: Update Intel Compute Runtime to v26.05

### DIFF
--- a/ollama-ipex/CHANGELOG.md
+++ b/ollama-ipex/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2026.3.1] 2026-09-16
+
+### Update:
+
+* oneAPI Level Zero Loader v1.28.2
+* Intel Graphics Compiler v2.28.4
+* Intel Compute Runtime v26.05
+
 ## [2025.11.1] 2025-11-16
 
 - Remove deprecated `codenotary` fields

--- a/ollama-ipex/Dockerfile
+++ b/ollama-ipex/Dockerfile
@@ -53,16 +53,16 @@ RUN \
 RUN \
     mkdir -p /tmp/gpu && \
     cd /tmp/gpu && \
-    echo "Downloading oneAPI Level Zero Loader v1.26.0..." && \
-    wget https://github.com/oneapi-src/level-zero/releases/download/v1.26.0/level-zero_1.26.0+u24.04_amd64.deb && \
-    echo "Downloading Intel Graphics Compiler v2.20.3..." && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.20.3/intel-igc-core-2_2.20.3+19972_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.20.3/intel-igc-opencl-2_2.20.3+19972_amd64.deb && \
-    echo "Downloading Intel Compute Runtime v25.40..." && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.40.35563.4/intel-ocloc_25.40.35563.4-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.40.35563.4/intel-opencl-icd_25.40.35563.4-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.40.35563.4/libigdgmm12_22.8.2_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.40.35563.4/libze-intel-gpu1_25.40.35563.4-0_amd64.deb && \
+    echo "Downloading oneAPI Level Zero Loader v1.28.2..." && \
+    wget https://github.com/oneapi-src/level-zero/releases/download/v1.28.2/level-zero_1.28.2+u24.04_amd64.deb && \
+    echo "Downloading Intel Graphics Compiler v2.28.4..." && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.28.4/intel-igc-core-2_2.28.4+20760_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.28.4/intel-igc-opencl-2_2.28.4+20760_amd64.deb && \
+    echo "Downloading Intel Compute Runtime v26.05..." && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/intel-ocloc_26.05.37020.3-0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/intel-opencl-icd_26.05.37020.3-0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/libigdgmm12_22.9.0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/libze-intel-gpu1_26.05.37020.3-0_amd64.deb && \
     dpkg -i --force-all *.deb && \
     rm *.deb
 

--- a/ollama-ipex/config.yaml
+++ b/ollama-ipex/config.yaml
@@ -1,6 +1,6 @@
 name: "Ollama IPEX"
 description: "Get up and running with large language models."
-version: "2025.11.1"
+version: "2026.3.1"
 slug: "ollama-ipex"
 
 arch:


### PR DESCRIPTION
* oneAPI Level Zero Loader v1.28.2
* Intel Graphics Compiler v2.28.4
* Intel Compute Runtime v26.05